### PR TITLE
shapefile write update

### DIFF
--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -32,7 +32,7 @@ create_input_shapefile <- function(input_csv, path) {
   coordinates(input) <- ~Longitude + Latitude
   crs(input) <- CRS("+proj=longlat +datum=NAD83")
   input <- spTransform(input, proj_inmap)
-  shapefile(input, file.path(path, "emis/ptegu.shp"), overwrite = TRUE)
+  writeSpatialShape(input, file.path(path, "emis/ptegu"))
 }
 
 #' Copy inMAP setup files to the run folder


### PR DESCRIPTION
This will require a new package (maptools), gives 2 warning messages:
 `Warning messages:
1: use rgdal::readOGR or sf::st_read
2. use rgdal::readOGR or sf::st_read`

And doesn't write over the ptegu.prj file. 

Not sure if this is the best solution in the end, but it does write the ptegu.dbf, ptegu.shp, and ptegu.shx files.