### PR TITLE
Addition of two functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,5 +13,11 @@ Depends:
     raster,
     proj4,
     sp,
-    tidyr
+    tidyr,
+    data.table
+Suggests:
+    dplyr,
+    ggplot2,
+    parallel,
+    sf
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,7 @@ Depends:
 Suggests:
     ggplot2,
     parallel,
-    sf
+    sf,
+    viridis,
+    scales
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,9 @@ Depends:
     proj4,
     sp,
     tidyr,
+    dplyr,
     data.table
 Suggests:
-    dplyr,
     ggplot2,
     parallel,
     sf

--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -247,10 +247,9 @@ combine_inmap_output <- function(path.out,
 #' @param cores Cores available to create plots. Defaults to one
 #' 
 #' @return A list of ggplot objects.
-              
 plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',cores=1){
 	#check if required packages are installed
-	try(if(F %in% (c('sf','parallel','ggplot2') %in% (.packages()))) stop("Required package missing! (need sf,parallel,ggplot2)"))
+	try(if(F %in% (c('sf','parallel','ggplot2','viridis','scales') %in% (.packages()))) stop("Required package missing! (need sf,parallel,ggplot2,viridis,scales)"))
 
 	#create directory if it does not exist
 	if (!file.exists(path.plot)) dir.create(path.plot)
@@ -277,8 +276,8 @@ plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',
 					geom_polygon(data= usa.states, aes(x = long, y = lat, group = group),
 								 fill = NA, colour = "grey50",size=.25) + 
 					coord_sf(xlim = c(-123,-69),ylim=c(24,50),datum=NA) + 
-					scale_color_viridis(discrete=F,option='D',limits= ll,oob=squish) +
-					scale_fill_viridis(discrete=F,option='D',limits= ll,oob=squish) + 
+					scale_color_viridis(discrete=F,option='D',limits= ll,oob=squish,direction=-1) +
+					scale_fill_viridis(discrete=F,option='D',limits= ll,oob=squish,direction=-1) + 
 					theme(legend.position = c(.25,.15),	axis.text=element_blank(), 
 						axis.title.x = element_blank(),axis.title.y = element_blank(),legend.title=element_blank(),
 						axis.title=element_text(size=24),legend.text=element_text(size = 14),
@@ -293,4 +292,4 @@ plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',
 	stopCluster(cl)
 	return(out)
 }
-               
+             

--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -241,10 +241,11 @@ combine_inmap_output <- function(path.out,
 #' @param read_inmap_d Directory that houses InMAP output csv files
 #' @param legend_lims Legend limits for zip code fill
 #' @param path.plot Output directory for plots. If it does not exist, it will be created
+#' @param cores Cores available to create plots. Defaults to one
 #' 
 #' @return A list of ggplot objects.
               
-plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots'){
+plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',cores=1){
 	#create directory if it does not exist
 	if (!file.exists(path.plot)) dir.create(path.plot)
 	
@@ -253,7 +254,7 @@ plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots')
 	
 	#read in USA and state shapes
 	usa.states <- map_data("state")
-	cl <- makeCluster(detectCores() - 1)
+	cl <- makeCluster(cores)
 	clusterExport(cl,c( 'data.table','ggplot','aes','theme_bw','geom_sf',
 						'labs','geom_polygon','coord_sf','scale_color_viridis',
 						'scale_fill_viridis','theme','element_text','element_rect',

--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -198,7 +198,7 @@ create_input_facility_all_but_one <- function(input_csv, path = basename(input_c
 #' data for plotting.
 #' 
 #' \code{combine_inmap_output} uses spatial linkages of an inMAP outputs to combine output
-#' multiple runs. Employs the sf package.
+#' multiple runs. Employs the sf package to link with spatial data if it is installed.
 #' 
 #' @param path.out Directory that houses InMAP output csv files
 #' @param zcta_shapefile A ZCTA shapefile
@@ -239,7 +239,7 @@ combine_inmap_output <- function(path.out,
 #' at zip code level compared to base year.
 #' 
 #' \code{combine_inmap_output} uses spatial linkages of an inMAP outputs to combine output
-#' multiple runs. Employs the sf, ggplot2, and parallel packages.
+#' multiple runs. Requires the sf, ggplot2, and parallel packages.
 #' 
 #' @param read_inmap_d Directory that houses InMAP output csv files
 #' @param legend_lims Legend limits for zip code fill

--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -249,7 +249,7 @@ combine_inmap_output <- function(path.out,
 #' @return A list of ggplot objects.
 plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',cores=1){
 	#check if required packages are installed
-	try(if(F %in% (c('sf','parallel','ggplot2','viridis','scales') %in% (.packages()))) stop("Required package missing! (need sf,parallel,ggplot2,viridis,scales)"))
+	if(F %in% (c('sf','parallel','ggplot2','viridis','scales') %in% (.packages()))) {stop("Required package missing! (need sf,parallel,ggplot2,viridis,scales)")}
 
 	#create directory if it does not exist
 	if (!file.exists(path.plot)) dir.create(path.plot)

--- a/R/rinmap.R
+++ b/R/rinmap.R
@@ -206,16 +206,19 @@ create_input_facility_all_but_one <- function(input_csv, path = basename(input_c
 #' 
 #' @return A data frame of average PM2.5 values at the ZIP code level.
 combine_inmap_output <- function(path.out,
-					   			 zcta_shapefile = "~/shared_space/ci3_nsaph/software/inmap/zcta/cb_2015_us_zcta510_500k.shp",
-					   			 pattern){
+				 zcta_shapefile = "~/shared_space/ci3_nsaph/software/inmap/zcta/cb_2015_us_zcta510_500k.shp",
+				 pattern){
+	#check if required packages are installed
+	try(if(F %in% (c('sf','dplyr') %in% (.packages()))) stop("Required package missing! (need sf,dplyr)"))
+
 	#list files for import, read in files
 	files = list.files(path.out,full.names=T)
 	names.f = gsub('_linked_zip.csv','', list.files(path.out,full.names=F))
 	names(files) <- names.f
 	if (!missing(pattern)) files = files[grep(pattern,names(files))]
 	im <- lapply(seq_along(files),function(x,f,n) {	fin <- fread(f[x])[,V1 := NULL]
-													setnames(fin,'PM25inMAP', n[x])
-													fin},files,names(files))
+							       setnames(fin,'PM25inMAP', n[x])
+							       fin},files,names(files))
 	
 	#reduce list to single data table
 	im <- Reduce(function(...) merge(..., all = TRUE, by = c("ZCTA","ZIP","PO_NAME","STATE","ZIP_TYPE")), im)
@@ -246,6 +249,9 @@ combine_inmap_output <- function(path.out,
 #' @return A list of ggplot objects.
               
 plot_inmap <- function(read_inmap_d,legend_lims=c(-5,5),path.plot='InMAP_plots',cores=1){
+	#check if required packages are installed
+	try(if(F %in% (c('sf','parallel','ggplot2') %in% (.packages()))) stop("Required package missing! (need sf,parallel,ggplot2)"))
+
 	#create directory if it does not exist
 	if (!file.exists(path.plot)) dir.create(path.plot)
 	


### PR DESCRIPTION
combine_inmap_output uses spatial linkages of an inMAP outputs to combine output multiple runs. Employs the sf package. The goal here to is make it easier to plot/analyze many InMAP run output files simultaneously. User provides a directory that contains InMAP output and an optional pattern that matches specific files in the directory

plot_inmap takes output from combine_inmap_output and saves spatial plots to a directory